### PR TITLE
🔧 Fix: Remove 'use server' directive causing deployment errors

### DIFF
--- a/lib/mappls-direct-api.ts
+++ b/lib/mappls-direct-api.ts
@@ -1,5 +1,4 @@
 // Mappls Direct API Service - Using REST APIs without SDK
-"use server";
 
 const MAPPLS_API_BASE = 'https://apis.mappls.com';
 


### PR DESCRIPTION
## 🐛 Problem
The deployment was failing on Vercel with this error:
```
Error: A 'use server' file can only export async functions, found object.
```

## 🔧 Solution
- Removed the `'use server'` directive from `lib/mappls-direct-api.ts`
- This file exports both async functions AND objects/types, so it cannot use `'use server'`
- The `'use server'` directive is only for files that exclusively contain Server Actions (async functions)

## ✅ Result
- ✅ Build now passes successfully
- ✅ Deployment error resolved
- ✅ No functionality changes, just directive removal

## 📋 Changes
- **File:** `lib/mappls-direct-api.ts`
- **Change:** Removed line 2: `'use server';`

The fix maintains all existing functionality while resolving the Next.js build constraint.